### PR TITLE
getPluginSlugFromTrace warnings list fix

### DIFF
--- a/js/deprecation-notice.js
+++ b/js/deprecation-notice.js
@@ -118,7 +118,7 @@ jQuery( document ).ready( function( $ ) {
 
 	if ( warnings.length ) {
 		warnings.forEach( function( entry ) {
-			const trace = getPluginSlugFromTrace( entry.trace );
+			const trace = getPluginSlugFromTrace( entry.trace ? entry.trace : "" );
 			let message = trace ? trace + ': ' : '';
 
 			message += entry.warning;


### PR DESCRIPTION
This prevents `getPluginSlugFromTrace` from being called with undefined, fixing #13